### PR TITLE
feat: breaks prop

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['react'],
+  plugins: ['react', 'react-hooks'],
   rules: {
     'no-var': 'warn',
     'no-unused-vars': 'warn',
@@ -10,6 +10,8 @@ module.exports = {
     'react/jsx-uses-vars': 'warn',
     'react/jsx-key': 'warn',
     'react/jsx-no-undef': 'error',
+    'react-hooks/rules-of-hooks': 'warn',
+    'react-hooks/exhaustive-deps': 'warn',
   },
   env: {
     node: true,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-jest": "^24.9.0",
     "eslint": "^6.2.2",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^2.4.0",
     "husky": "^3.0.4",
     "jest": "^24.9.0",
     "microbundle": "^0.11.0",

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -10,7 +10,12 @@ afterEach(cleanup)
 describe('Markdown', () => {
   const markdown = `
   # React
+
   ## A JavaScript library for interfaces.
+
+  A paragraph
+  with a break
+
   [Get started](https://reactjs.org/docs/getting-started.html)
   `
 
@@ -75,6 +80,33 @@ describe('Markdown', () => {
     expect(container).toContainElement(heading6)
     expect(container).toContainElement(p)
     expect(container).toContainElement(a)
+  })
+
+  it('supports toggling breaks support', () => {
+    const { getByText } = render(<MarkdownRenderer markdown={markdown} />)
+
+    expect(getByText('A paragraph with a break')).toMatchInlineSnapshot(`
+      <p>
+          A paragraph
+        <br />
+        
+
+        with a break
+      </p>
+    `)
+
+    cleanup()
+
+    const { getByText: getByText2 } = render(
+      <MarkdownRenderer markdown={markdown} breaks={false} />
+    )
+
+    expect(getByText2('A paragraph with a break')).toMatchInlineSnapshot(`
+      <p>
+          A paragraph
+      with a break
+      </p>
+    `)
   })
 
   it('handles merging component overrides', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,44 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import remark from 'remark'
-import remarkBreaks from 'remark-breaks'
 import remarkReact from 'remark-react'
+import remarkBreaks from 'remark-breaks'
 
 export const MarkdownRenderer = ({
   markdown,
   components = {},
-  componentOverrides,
+  componentOverrides = {},
+  breaks = true,
 }) => {
-  const resolvedComponents = componentOverrides
-    ? Object.keys(componentOverrides).reduce((acc, key) => {
-        const Comp =
-          components[key] || (props => React.createElement(key, props))
+  const resolvedComponents = useMemo(
+    () =>
+      Object.keys(componentOverrides).reduce(
+        (acc, key) => {
+          const Comp =
+            components[key] || (props => React.createElement(key, props))
 
-        acc[key] = componentOverrides[key](Comp)
+          acc[key] = componentOverrides[key](Comp)
 
-        return acc
-      }, components)
-    : { ...components }
+          return acc
+        },
+        { ...components }
+      ),
+    [components, componentOverrides]
+  )
 
-  return remark()
-    .use(remarkReact, {
+  const instance = useMemo(() => {
+    const r = remark().use(remarkReact, {
       remarkReactComponents: resolvedComponents,
     })
-    .use(remarkBreaks)
-    .processSync(markdown).contents
+
+    if (breaks) r.use(remarkBreaks)
+
+    return r
+  }, [breaks, resolvedComponents])
+
+  return useMemo(() => instance.processSync(markdown).contents, [
+    instance,
+    markdown,
+  ])
 }
 
 export default MarkdownRenderer

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,6 +3114,11 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-react-hooks@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.4.0.tgz#db6ee1cc953e3a217035da3d4e9d4356d3c672a4"
+  integrity sha512-bH5DOCP6WpuOqNaux2BlaDCrSgv8s5BitP90bTgtZ1ZsRn2bdIfeMDY5F2RnJVnyKDy6KRQRDbipPLZ1y77QtQ==
+
 eslint-plugin-react@^7.14.3:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"


### PR DESCRIPTION
- Adds `breaks` prop that toggles `remark-break` support (enabled by default)
- Memoizes implementation via `useMemo`